### PR TITLE
Update examples to 3.3.57

### DIFF
--- a/ASP.NET-MVC/BookShop/BookShop.AcceptanceTests/BookShop.AcceptanceTests.csproj
+++ b/ASP.NET-MVC/BookShop/BookShop.AcceptanceTests/BookShop.AcceptanceTests.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="Selenium.Firefox.WebDriver" Version="0.26.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="83.0.4103.3900" />
     <PackageReference Include="Selenium.WebDriver.MicrosoftDriver" Version="17.17134.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.57" />
     <PackageReference Include="SpecRun.SpecFlow" Version="3.3.17" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.4" />

--- a/AdditionalStepAssembly/AdditionalStepAssembly/AdditionalStepAssembly.csproj
+++ b/AdditionalStepAssembly/AdditionalStepAssembly/AdditionalStepAssembly.csproj
@@ -8,8 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/AdditionalStepAssembly/AdditionalStepAssemblyFullFramework/AdditionalStepAssemblyFullFramework.csproj
+++ b/AdditionalStepAssembly/AdditionalStepAssemblyFullFramework/AdditionalStepAssemblyFullFramework.csproj
@@ -8,8 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/AdditionalStepAssembly/SecondStepAssembly/SecondStepAssembly.csproj
+++ b/AdditionalStepAssembly/SecondStepAssembly/SecondStepAssembly.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
   </ItemGroup>
 
 </Project>

--- a/AsyncAwait/WebRequest.Specs/WebRequest.Specs.csproj
+++ b/AsyncAwait/WebRequest.Specs/WebRequest.Specs.csproj
@@ -6,9 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />

--- a/BowlingKata/BowlingKata-FluentAssertions/Bowling.SpecFlow/Bowling.SpecFlow.csproj
+++ b/BowlingKata/BowlingKata-FluentAssertions/Bowling.SpecFlow/Bowling.SpecFlow.csproj
@@ -9,9 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/BowlingKata/BowlingKata-Fsharp/Bowling.SpecFlow.Bindings/Bowling.SpecFlow.Bindings.csproj
+++ b/BowlingKata/BowlingKata-Fsharp/Bowling.SpecFlow.Bindings/Bowling.SpecFlow.Bindings.csproj
@@ -8,9 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/BowlingKata/BowlingKata-Fsharp/Bowling.SpecFlow/Bowling.SpecFlow.fsproj
+++ b/BowlingKata/BowlingKata-Fsharp/Bowling.SpecFlow/Bowling.SpecFlow.fsproj
@@ -14,8 +14,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/BowlingKata/BowlingKata-German/Bowling.SpecFlow/Bowling.SpecFlow.csproj
+++ b/BowlingKata/BowlingKata-German/Bowling.SpecFlow/Bowling.SpecFlow.csproj
@@ -9,9 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/BowlingKata/BowlingKata-MsTest/Bowling.SpecFlow/Bowling.SpecFlow.csproj
+++ b/BowlingKata/BowlingKata-MsTest/Bowling.SpecFlow/Bowling.SpecFlow.csproj
@@ -10,12 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.MsTest" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.MsTest" Version="3.3.57" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BowlingKata/BowlingKata-Nunit/Bowling.SpecFlow/Bowling.SpecFlow.csproj
+++ b/BowlingKata/BowlingKata-Nunit/Bowling.SpecFlow/Bowling.SpecFlow.csproj
@@ -9,9 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.3.57" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1">
       <PrivateAssets>all</PrivateAssets>

--- a/BowlingKata/BowlingKata-VB-MsTest/Bowling.SpecFlow/Bowling.SpecFlow.vbproj
+++ b/BowlingKata/BowlingKata-VB-MsTest/Bowling.SpecFlow/Bowling.SpecFlow.vbproj
@@ -10,12 +10,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.MsTest" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.MsTest" Version="3.3.57" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BowlingKata/BowlingKata-XUnit/Bowling.Specflow/Bowling.Specflow.csproj
+++ b/BowlingKata/BowlingKata-XUnit/Bowling.Specflow/Bowling.Specflow.csproj
@@ -9,9 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/GherkinFormattingExamples/GherkinFormattingExamples/GherkinFormattingExamples/GherkinFormattingExamples.csproj
+++ b/GherkinFormattingExamples/GherkinFormattingExamples/GherkinFormattingExamples/GherkinFormattingExamples.csproj
@@ -8,9 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/NETCore Examples/BowlingKata-SpecFlowJson-MsTest/Bowling.SpecFlowMsTest/Bowling.SpecFlowMsTest.csproj
+++ b/NETCore Examples/BowlingKata-SpecFlowJson-MsTest/Bowling.SpecFlowMsTest/Bowling.SpecFlowMsTest.csproj
@@ -9,9 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.MsTest" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.MsTest" Version="3.3.57" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.7.0" />

--- a/NETCore Examples/BowlingKata-SpecFlowJson-NUnit/Bowling.SpecFlowNUnit/Bowling.SpecFlowNUnit.csproj
+++ b/NETCore Examples/BowlingKata-SpecFlowJson-NUnit/Bowling.SpecFlowNUnit/Bowling.SpecFlowNUnit.csproj
@@ -11,9 +11,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.3.57" />
     <PackageReference Include="FluentAssertions" Version="5.7.0" />
   </ItemGroup>
 

--- a/NETCore Examples/BowlingKata-SpecFlowJson-xUnit/Bowling.SpecFlowXUnit/Bowling.SpecFlowXUnit.csproj
+++ b/NETCore Examples/BowlingKata-SpecFlowJson-xUnit/Bowling.SpecFlowXUnit/Bowling.SpecFlowXUnit.csproj
@@ -8,9 +8,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Plugins/CombinedPlugin/GeneratorPlugin/SampleGeneratorPlugin.csproj
+++ b/Plugins/CombinedPlugin/GeneratorPlugin/SampleGeneratorPlugin.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpecFlow.CustomPlugin" Version="3.3.30" />
+    <PackageReference Include="SpecFlow.CustomPlugin" Version="3.3.57" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Plugins/CombinedPlugin/RuntimePlugin/SampleRuntimePlugin.csproj
+++ b/Plugins/CombinedPlugin/RuntimePlugin/SampleRuntimePlugin.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
   </ItemGroup>
 
 </Project>

--- a/Plugins/GeneratorOnlyPlugin/GeneratorPlugin/SampleGeneratorPlugin.csproj
+++ b/Plugins/GeneratorOnlyPlugin/GeneratorPlugin/SampleGeneratorPlugin.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpecFlow.CustomPlugin" Version="3.3.30" />
+    <PackageReference Include="SpecFlow.CustomPlugin" Version="3.3.57" />
   </ItemGroup>
 
 

--- a/Plugins/RuntimeOnlyPlugin/RuntimePlugin/SampleRuntimePlugin.csproj
+++ b/Plugins/RuntimeOnlyPlugin/RuntimePlugin/SampleRuntimePlugin.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
   </ItemGroup>
 
 </Project>

--- a/Refactorings/ScenarioFeatureContextInjection/after/ScenarioFeatureContextInjection/ScenarioFeatureContextInjection.csproj
+++ b/Refactorings/ScenarioFeatureContextInjection/after/ScenarioFeatureContextInjection/ScenarioFeatureContextInjection.csproj
@@ -5,8 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit.assert" Version="2.4.1" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/Refactorings/ScenarioFeatureContextInjection/before/ScenarioFeatureContextInjection/ScenarioFeatureContextInjection.csproj
+++ b/Refactorings/ScenarioFeatureContextInjection/before/ScenarioFeatureContextInjection/ScenarioFeatureContextInjection.csproj
@@ -5,8 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit.assert" Version="2.4.1" />
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/SpecFlow.json/BowlingKata-SpecFlowJson-MsTest/Bowling.SpecFlowMsTest/Bowling.SpecFlowMsTest.csproj
+++ b/SpecFlow.json/BowlingKata-SpecFlowJson-MsTest/Bowling.SpecFlowMsTest/Bowling.SpecFlowMsTest.csproj
@@ -10,9 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.MsTest" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.MsTest" Version="3.3.57" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />

--- a/SpecFlow.json/BowlingKata-SpecFlowJson-NUnit/Bowling.SpecFlowNUnit/Bowling.SpecFlowNUnit.csproj
+++ b/SpecFlow.json/BowlingKata-SpecFlowJson-NUnit/Bowling.SpecFlowNUnit/Bowling.SpecFlowNUnit.csproj
@@ -11,9 +11,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.3.57" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
   </ItemGroup>
 

--- a/SpecFlow.json/BowlingKata-SpecFlowJson-xUnit/Bowling.SpecFlowXUnit/Bowling.SpecFlowXUnit.csproj
+++ b/SpecFlow.json/BowlingKata-SpecFlowJson-xUnit/Bowling.SpecFlowXUnit/Bowling.SpecFlowXUnit.csproj
@@ -10,9 +10,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/SpecialChars/SpecialChars/SpecialChars.csproj
+++ b/SpecialChars/SpecialChars/SpecialChars.csproj
@@ -6,9 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="SpecFlow" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.3.30" />
-    <PackageReference Include="SpecFlow.xUnit" Version="3.3.30" />
+    <PackageReference Include="SpecFlow" Version="3.3.57" />
+    <PackageReference Include="SpecFlow.xUnit" Version="3.3.57" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Remove SpecFlow.Tools.MsBuild.Generation package (it is contained in the plugins)