### PR TITLE
Plugin frameworks

### DIFF
--- a/Plugins/CombinedPlugin/GeneratorPlugin/SampleGeneratorPlugin.csproj
+++ b/Plugins/CombinedPlugin/GeneratorPlugin/SampleGeneratorPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NuspecFile>$(MSBuildThisFileDirectory)SamplePlugin.nuspec</NuspecFile>
     <AssemblyName>SampleGeneratorPlugin.SpecFlowPlugin</AssemblyName>

--- a/Plugins/CombinedPlugin/GeneratorPlugin/SamplePlugin.nuspec
+++ b/Plugins/CombinedPlugin/GeneratorPlugin/SamplePlugin.nuspec
@@ -13,10 +13,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>specflow</tags>
     <!--<dependencies>
-      <group targetFramework="net45">
+      <group targetFramework="net471">
         <dependency id="SpecFlow" version="insert specflow version here"/>
       </group>
-      <group targetFramework="netstandard2.0">
+      <group targetFramework="netcoreapp2.1">
         <dependency id="SpecFlow" version="insert specflow version here"/>
       </group>
     </dependencies>-->
@@ -24,13 +24,13 @@
   <files>
     <file src="build\**\*" target="build"/>
 
-    <file src="bin\$config$\net471\SampleRuntimePlugin.SpecFlowPlugin.*" target="lib\net45"/>
-    <file src="bin\$config$\netstandard2.0\SampleRuntimePlugin.SpecFlowPlugin.dll" target="lib\netstandard2.0"/>
-    <file src="bin\$config$\netstandard2.0\SampleRuntimePlugin.SpecFlowPlugin.pdb" target="lib\netstandard2.0"/>
+    <file src="bin\$config$\net471\SampleRuntimePlugin.SpecFlowPlugin.*" target="lib\net471"/>
+    <file src="bin\$config$\netcoreapp2.1\SampleRuntimePlugin.SpecFlowPlugin.dll" target="lib\netcoreapp2.1"/>
+    <file src="bin\$config$\netcoreapp2.1\SampleRuntimePlugin.SpecFlowPlugin.pdb" target="lib\netcoreapp2.1"/>
     
     <file src="bin\$config$\net471\SampleGeneratorPlugin.SpecFlowPlugin.*" target="build\net471"/>
-    <file src="bin\$config$\netstandard2.0\SampleGeneratorPlugin.SpecFlowPlugin.dll" target="build\netstandard2.0"/>
-    <file src="bin\$config$\netstandard2.0\SampleGeneratorPlugin.SpecFlowPlugin.pdb" target="build\netstandard2.0"/>
+    <file src="bin\$config$\netcoreapp2.1\SampleGeneratorPlugin.SpecFlowPlugin.dll" target="build\netcoreapp2.1"/>
+    <file src="bin\$config$\netcoreapp2.1\SampleGeneratorPlugin.SpecFlowPlugin.pdb" target="build\netcoreapp2.1"/>
 
 
   </files>

--- a/Plugins/CombinedPlugin/GeneratorPlugin/build/SpecFlow.SamplePlugin.targets
+++ b/Plugins/CombinedPlugin/GeneratorPlugin/build/SpecFlow.SamplePlugin.targets
@@ -1,12 +1,12 @@
 ﻿<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_SampleGeneratorPluginFramework Condition=" '$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</_SampleGeneratorPluginFramework>
+    <_SampleGeneratorPluginFramework Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.1</_SampleGeneratorPluginFramework>
     <_SampleGeneratorPluginFramework Condition=" '$(MSBuildRuntimeType)' != 'Core'">net471</_SampleGeneratorPluginFramework>
 
     <_SampleGeneratorPluginPath>$(MSBuildThisFileDirectory)\$(_SampleGeneratorPluginFramework)\SampleGeneratorPlugin.SpecFlowPlugin.dll</_SampleGeneratorPluginPath>
 
-    <_SampleRuntimePluginFramework Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">netstandard2.0</_SampleRuntimePluginFramework>
-    <_SampleRuntimePluginFramework Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">net45</_SampleRuntimePluginFramework>
+    <_SampleRuntimePluginFramework Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' ">netcoreapp2.1</_SampleRuntimePluginFramework>
+    <_SampleRuntimePluginFramework Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">net471</_SampleRuntimePluginFramework>
     <_SampleRuntimePluginPath>$(MSBuildThisFileDirectory)\..\lib\$(_SampleRuntimePluginFramework)\SampleRuntimePlugin.SpecFlowPlugin.dll</_SampleRuntimePluginPath>
   </PropertyGroup>
 </Project>

--- a/Plugins/GeneratorOnlyPlugin/GeneratorPlugin/SampleGeneratorPlugin.csproj
+++ b/Plugins/GeneratorOnlyPlugin/GeneratorPlugin/SampleGeneratorPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NuspecFile>$(MSBuildThisFileDirectory)SamplePlugin.nuspec</NuspecFile>
     <AssemblyName>SampleGeneratorPlugin.SpecFlowPlugin</AssemblyName>

--- a/Plugins/GeneratorOnlyPlugin/GeneratorPlugin/SamplePlugin.nuspec
+++ b/Plugins/GeneratorOnlyPlugin/GeneratorPlugin/SamplePlugin.nuspec
@@ -21,8 +21,8 @@
 
     
     <file src="bin\$config$\net471\SampleGeneratorPlugin.SpecFlowPlugin.*" target="build\net471"/>
-    <file src="bin\$config$\netstandard2.0\SampleGeneratorPlugin.SpecFlowPlugin.dll" target="build\netstandard2.0"/>
-    <file src="bin\$config$\netstandard2.0\SampleGeneratorPlugin.SpecFlowPlugin.pdb" target="build\netstandard2.0"/>
+    <file src="bin\$config$\netcoreapp2.1\SampleGeneratorPlugin.SpecFlowPlugin.dll" target="build\netcoreapp2.1"/>
+    <file src="bin\$config$\netcoreapp2.1\SampleGeneratorPlugin.SpecFlowPlugin.pdb" target="build\netcoreapp2.1"/>
 
 
   </files>

--- a/Plugins/GeneratorOnlyPlugin/GeneratorPlugin/build/SpecFlow.SamplePlugin.targets
+++ b/Plugins/GeneratorOnlyPlugin/GeneratorPlugin/build/SpecFlow.SamplePlugin.targets
@@ -1,6 +1,6 @@
 ﻿<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <_SampleGeneratorPluginFramework Condition=" '$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</_SampleGeneratorPluginFramework>
+    <_SampleGeneratorPluginFramework Condition=" '$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.1</_SampleGeneratorPluginFramework>
     <_SampleGeneratorPluginFramework Condition=" '$(MSBuildRuntimeType)' != 'Core'">net471</_SampleGeneratorPluginFramework>
 
     <_SampleGeneratorPluginPath>$(MSBuildThisFileDirectory)\$(_SampleGeneratorPluginFramework)\SampleGeneratorPlugin.SpecFlowPlugin.dll</_SampleGeneratorPluginPath>


### PR DESCRIPTION
As per 
https://github.com/SpecFlowOSS/SpecFlow/issues/1912 and
https://github.com/SpecFlowOSS/SpecFlow/pull/1968

Generator plugins are no longer compatible with net standard, only core.

I've updated the samples accordingly.